### PR TITLE
Allow OPTIONS request even if the user is not authenticated.

### DIFF
--- a/Configuration.md
+++ b/Configuration.md
@@ -200,7 +200,6 @@ Example
     </server-config>
 
 ## `<ssl-cert>`
-
 Specifies a certificate to use for ssl server identification.  You can specify as many certificates as you need and the server will automatically pick the correct one for the domain name being requested.
 
 Contains
@@ -223,6 +222,18 @@ Example
 				<key>/etc/ssl/private/server.key</key>
 			</ssl-cert>
         </server>
+    </server-config>
+
+## `<unprotect-options>`
+Set `<unprotect-options>` to true if you would like to make OPTIONS requests available without previous authentication. This might be required for your CORS setup.
+
+Note that this exposes the features of the server to everyone requesting them.
+
+Example
+
+    <server-config xmlns="http://couling.me/webdavd">
+        <unprotect-options>true</unprotect-options>
+        <server><listen><port>80</port></listen></server>
     </server-config>
 
 ## Time Format

--- a/configuration.c
+++ b/configuration.c
@@ -269,6 +269,19 @@ static int configResponseDir(WebdavdConfiguration * config, xmlTextReaderPtr rea
 	return result;
 }
 
+static int configUnprotectOptions(WebdavdConfiguration * config, xmlTextReaderPtr reader, const char * configFile) {
+        // <unprotect-options>~</unprotect-options>
+	const char * valueString;
+	int result = stepOverText(reader, &valueString);
+	if ( valueString && !strcmp(valueString, "true") ) {
+		xmlFree((char *) valueString);
+                config->unprotectOptions = 1;
+        } else { 
+		config->unprotectOptions = 0;
+	}	
+	return result;
+}
+
 ///////////////////////////
 // End Handler Functions //
 ///////////////////////////
@@ -302,7 +315,8 @@ static const ConfigurationFunction configFunctions[] = {
 		{ .nodeName = "restricted", .func = &configRestricted },               // <restricted />
 		{ .nodeName = "session-timeout", .func = &configSessionTimeout },      // <session-timeout />
 		{ .nodeName = "ssl-cert", .func = &configConfigSSLCert },              // <ssl-cert />
-		{ .nodeName = "static-response-dir", .func = &configResponseDir }      // <static-response-dir />
+		{ .nodeName = "static-response-dir", .func = &configResponseDir },      // <static-response-dir />
+		{ .nodeName = "unprotect-options", .func = &configUnprotectOptions }   // <unprotect-options />
 };
 
 static int configFunctionCount = sizeof(configFunctions) / sizeof(*configFunctions);

--- a/configuration.h
+++ b/configuration.h
@@ -51,6 +51,10 @@ typedef struct WebdavdConfiguration {
 	// SSL
 	int sslCertCount;
 	SSLConfig * sslCerts;
+
+	// OPTIONS Requests
+	int unprotectOptions;
+
 } WebdavdConfiguration;
 
 extern WebdavdConfiguration config;

--- a/package-with/conf.xml
+++ b/package-with/conf.xml
@@ -119,5 +119,11 @@
 
 		<!-- As required.... -->
 		<!-- <ssl-cert> ... </ssl-cert> -->
+
+		<!-- Set "unprotect-options" to true if you would like to make OPTIONS requests
+                        available without previous authentication. This might be required for your CORS setup.
+			Note that this exposes the features of the server to everyone requesting them. -->
+		<!-- <unprotect-options>true</unprotect-options> -->
+
 	</server>
 </server-config>

--- a/webdavd.c
+++ b/webdavd.c
@@ -1771,6 +1771,15 @@ static int answerToRequest(void *cls, Request *request, const char *url, const c
 			logAccess(RAP_RESPOND_AUTH_FAILLED, method, rapSession->user, url, clientIp);
 			if (requestHasData(request)) {
 				return MHD_YES;
+
+			// If configured, OPTIONS should be returned even if authentication fails
+			} else if ( !strcmp("OPTIONS", method) && config.unprotectOptions ) {
+				Response * response = NULL;
+				response = createFileResponse(OPTIONS_PAGE, "text/html", rapSession);
+				addHeader(response, "Accept", ACCEPT_HEADER);
+
+				return sendResponse(request, RAP_RESPOND_OK, response, rapSession);
+
 			} else {
 				return sendResponse(request, RAP_RESPOND_AUTH_FAILLED, NULL, rapSession);
 			}


### PR DESCRIPTION
Set the flag <unprotect-options> to true to move OPTIONS requests out of the authentication requirements. This is useful in case of CORS problems.