### PR TITLE
Allow using a subdirectory of the user's home dir as chroot

### DIFF
--- a/package-with/conf.xml
+++ b/package-with/conf.xml
@@ -60,9 +60,10 @@
 			Supports format: [[[hours:]minutes:]seconds] -->
 		<session-timeout>5:00</session-timeout>
 
-		<!-- Chroot the server before serving requests.  This can be set to ~ forcing the
-			 server to chroot to the home directory per request.  Alternativly a static path
-			 can be specified. -->
+		<!-- Chroot the server before serving requests.  This can be set ~, or a path beginning with
+			~/ and then followed by additional directories, forcing the server to chroot to the
+			user's home directory, or a subdirectory of it, per request.  Alternatively a static
+			path can be specified.  -->
 		<chroot-path>~</chroot-path>
 
 		<!-- mime.types file default /etc/mime.types -->


### PR DESCRIPTION
Let chroot-path to contain additional path components after the '\~'.
E.g., a path like "~/html" will cause webdavd to chroot into the
specified subdirectory of the user's home dir.

This way just a user specific website can be served and not the entire
home directory tree.