### PR TITLE
Added custom header handler.

### DIFF
--- a/Configuration.md
+++ b/Configuration.md
@@ -177,6 +177,19 @@ Example
         <server><listen><port>80</port></listen></server>
     </server-config>
 
+
+## `<add-header>`
+It is possible to add custom response headers to the outgoing transactions by using `<add-header>` tags. This can for example be useful if you need to configure Cross Origin Resource Sharing (CORS).The headers are added to all outgoing reponses of the instance.
+
+The header name needs to be added to the tag attribute `name`. Its corresponding value is included inside the tags.
+
+Example
+
+    <server-config xmlns="http://couling.me/webdavd">
+        <add-header name="Access-Control-Allow-Origin">'https://www.example.com'</add-header>
+        <server><listen><port>80</port></listen></server>
+    </server-config>
+
 ## `<error-log>`
 The location to write the error log.  If unspecified the error log will be written to the stderr.
 

--- a/configuration.c
+++ b/configuration.c
@@ -278,7 +278,23 @@ static int configUnprotectOptions(WebdavdConfiguration * config, xmlTextReaderPt
                 config->unprotectOptions = 1;
         } else { 
 		config->unprotectOptions = 0;
-	}	
+	}
+	return result;
+}
+
+static int configAddHeader(WebdavdConfiguration * config, xmlTextReaderPtr reader, const char * configFile) {
+	//<add-header name="Access-Control-Allow-Headers">cache-control</add-header>
+
+	// keep track of the number of headers
+	int index = config->addHeadersCount++;
+
+	// increase the size of the config-->addHeaders memory area
+	config->addHeaders = reallocSafe(config->addHeaders, sizeof(*config->addHeaders) * config->addHeadersCount);
+	memset(&config->addHeaders[index], 0, sizeof(config->addHeaders[index]));
+
+	// add the values to the configurations
+	config->addHeaders[index].name = xmlTextReaderGetAttribute(reader, "name");
+	int result = readConfigString(reader, &config->addHeaders[index].value);
 	return result;
 }
 
@@ -303,6 +319,7 @@ static int compareConfigFunction(const void * a, const void * b) {
 // This MUST be sorted in aplabetical order (for nodeName).  The array is binary-searched.
 static const ConfigurationFunction configFunctions[] = {
 		{ .nodeName = "access-log", .func = &configAccessLog },                // <access-log />
+		{ .nodeName = "add-header", .func = &configAddHeader },                // <add-header />
 		{ .nodeName = "chroot-path", .func = &configChroot },                  // <chroot />
 		{ .nodeName = "error-log", .func = &configErrorLog },                  // <error-log />
 		{ .nodeName = "listen", .func = &configListen },                       // <listen />

--- a/configuration.h
+++ b/configuration.h
@@ -16,6 +16,11 @@ typedef struct DaemonConfig {
 	const char * forwardToHost;
 } DaemonConfig;
 
+typedef struct AddHeaders {
+	const char * name;
+	const char * value;
+} AddHeaders;
+
 typedef struct SSLConfig {
 	int chainFileCount;
 	const char * keyFile;
@@ -54,6 +59,10 @@ typedef struct WebdavdConfiguration {
 
 	// OPTIONS Requests
 	int unprotectOptions;
+
+	// Additional Headers
+	int addHeadersCount;
+	AddHeaders * addHeaders;
 
 } WebdavdConfiguration;
 

--- a/package-with/conf.xml
+++ b/package-with/conf.xml
@@ -53,7 +53,7 @@
 		</listen>
 
 
-		<!-- The authenticated session life span (has secirity implications). Sessions 
+		<!-- The authenticated session life span (has security implications). Sessions 
 			will stay open for this length of time and user/passwords matching the session 
 			may not be checked with PAM. For this reason it is best to leave this open 
 			only for a few minutes incase the system password changes. default: 5:00 
@@ -125,6 +125,11 @@
                         available without previous authentication. This might be required for your CORS setup.
 			Note that this exposes the features of the server to everyone requesting them. -->
 		<!-- <unprotect-options>true</unprotect-options> -->
+
+		<!-- Add custom reply headers here. This can for example be useful if you need
+			to configure Cross Origin Resource Sharing (CORS). -->
+		<!-- <add-header name="Access-Control-Allow-Origin">'https://www.example.com'</add-header> -->
+		<!-- <add-header name="Access-Control-Allow-Headers">'cache-control'</add-header> -->
 
 	</server>
 </server-config>

--- a/webdavd.c
+++ b/webdavd.c
@@ -1216,6 +1216,11 @@ static Response * createFdResponse(int fd, uint64_t offset, uint64_t size, const
 	addHeader(response, "Expires", "Thu, 19 Nov 1980 00:00:00 GMT");
 	addHeader(response, "Cache-Control", "no-store, no-cache, must-revalidate, post-check=0, pre-check=0");
 	addHeader(response, "Pragma", "no-cache");
+        // Adding additional headers from the config file
+        for (int i = 0; i < config.addHeadersCount; i++) {
+            addHeader(response, config.addHeaders[i].name, config.addHeaders[i].value);
+        }
+
 	return response;
 }
 


### PR DESCRIPTION
Users might need custom headers. Especially, if you want to allow CORS. For example:
Access-Control-Allow-Origin: 'https://www.example.com'
Access-Control-Allow-Headers: 'cache-control'

Enhancement #9 
Replaces PR #24 