### PR TITLE
Fix hangs reading xml

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -86,11 +86,12 @@ static int configListen(WebdavdConfiguration * config, xmlTextReaderPtr reader, 
 		if (xmlTextReaderNodeType(reader) == XML_READER_TYPE_ELEMENT
 				&& !strcmp(xmlTextReaderConstNamespaceUri(reader),
 				CONFIG_NAMESPACE)) {
-			if (!strcmp(xmlTextReaderConstLocalName(reader), "port")) {
+			const char * elementName = xmlTextReaderConstLocalName(reader);
+			if (!strcmp(elementName, "port")) {
 				result = readConfigInt(reader, &config->daemons[index].port, configFile);
-			} else if (!strcmp(xmlTextReaderConstLocalName(reader), "host")) {
+			} else if (!strcmp(elementName, "host")) {
 				result = readConfigString(reader, &config->daemons[index].host);
-			} else if (!strcmp(xmlTextReaderConstLocalName(reader), "encryption")) {
+			} else if (!strcmp(elementName, "encryption")) {
 				const char * encryptionString;
 				result = stepOverText(reader, &encryptionString);
 				if (encryptionString) {
@@ -104,7 +105,7 @@ static int configListen(WebdavdConfiguration * config, xmlTextReaderPtr reader, 
 					}
 					xmlFree((char *) encryptionString);
 				}
-			} else if (!strcmp(xmlTextReaderConstLocalName(reader), "forward-to")) {
+			} else if (!strcmp(elementName, "forward-to")) {
 				int depth2 = xmlTextReaderDepth(reader) + 1;
 				result = stepInto(reader);
 				config->daemons[index].forwardToIsEncrypted = -1;
@@ -143,6 +144,9 @@ static int configListen(WebdavdConfiguration * config, xmlTextReaderPtr reader, 
 								config->daemons[index].forwardToPort == 443 ? 1 : 0;
 					}
 				}
+			} else {
+				stdLogError(0, "Unknown element tag '%s' in listen section", elementName);
+				result = stepOver(reader);
 			}
 		} else {
 			result = stepOver(reader);

--- a/xml.c
+++ b/xml.c
@@ -23,11 +23,11 @@ int stepInto(xmlTextReaderPtr reader) {
 	int result;
 	do {
 		result = xmlTextReaderRead(reader);
-	} while (result
+	} while (result > 0
 			&& (xmlTextReaderNodeType(reader) == XML_READER_TYPE_SIGNIFICANT_WHITESPACE
 					|| xmlTextReaderNodeType(reader) == XML_READER_TYPE_COMMENT
 					|| xmlTextReaderNodeType(reader) == XML_READER_TYPE_END_ELEMENT));
-	return result;
+	return result > 0;
 }
 
 int stepOver(xmlTextReaderPtr reader) {
@@ -35,14 +35,14 @@ int stepOver(xmlTextReaderPtr reader) {
 	int result;
 	do {
 		result = xmlTextReaderRead(reader);
-	} while (result && xmlTextReaderDepth(reader) > depth);
-	while (result
+	} while (result > 0 && xmlTextReaderDepth(reader) > depth);
+	while (result > 0
 			&& (xmlTextReaderNodeType(reader) == XML_READER_TYPE_SIGNIFICANT_WHITESPACE
 					|| xmlTextReaderNodeType(reader) == XML_READER_TYPE_COMMENT
 					|| xmlTextReaderNodeType(reader) == XML_READER_TYPE_END_ELEMENT)) {
 		result = xmlTextReaderRead(reader);
 	}
-	return result;
+	return result > 0;
 }
 
 int stepOut(xmlTextReaderPtr reader) {
@@ -50,27 +50,27 @@ int stepOut(xmlTextReaderPtr reader) {
 	int result;
 	do {
 		result = xmlTextReaderRead(reader);
-	} while (result && xmlTextReaderDepth(reader) > depth);
-	while (result
+	} while (result > 0 && xmlTextReaderDepth(reader) > depth);
+	while (result > 0
 			&& (xmlTextReaderNodeType(reader) == XML_READER_TYPE_SIGNIFICANT_WHITESPACE
 					|| xmlTextReaderNodeType(reader) == XML_READER_TYPE_COMMENT
 					|| xmlTextReaderNodeType(reader) == XML_READER_TYPE_END_ELEMENT)) {
 		result = xmlTextReaderRead(reader);
 	}
-	return result;
+	return result > 0;
 }
 
 int stepOverText(xmlTextReaderPtr reader, const char ** text) {
 	int depth = xmlTextReaderDepth(reader);
 	int result = stepInto(reader);
 	*text = NULL;
-	if (result && xmlTextReaderDepth(reader) > depth) {
+	if (result > 0 && xmlTextReaderDepth(reader) > depth) {
 		if (xmlTextReaderNodeType(reader) == XML_READER_TYPE_TEXT) {
 			*text = xmlTextReaderValue(reader);
 		}
 		result = stepOut(reader);
 	}
-	return result;
+	return result > 0;
 }
 
 int elementMatches(xmlTextReaderPtr reader, const char * namespace, const char * nodeName) {


### PR DESCRIPTION
webdavd will hang in an infinite loop on startup for various simple mistakes in the xml.

Anything malformed, like missing a closing tag for an element.
<server> <listen> <listen-without-slash> </server>
<server> <listen> /listen> </server>

Any unknown element in a listen:
<listen> <typo> 1234 </typo> </listen>

Unknown elements in a server were handled.